### PR TITLE
Refactor note lengths

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -53,7 +53,7 @@ namespace music {
                 : parseInt(note.substr(0, i))
             note = note.slice(i)
 
-            let duration = Math.floor(32 / d);
+            let duration = Math.floor(32 / d); // Could remove call to Math.floor() to keep remainder
             if (dot)
                 duration += duration >> 1;
             // parsed, render to convert
@@ -67,7 +67,7 @@ namespace music {
         parts[1].split(',')
             .map(kvs => kvs.split('='))
             .forEach(kv => {
-                switch(kv[0]) { // Should be swtich(kv[0].trim())
+                switch(kv[0]) { // Should be switch(kv[0].trim())
                     case "d": defaultd = parseInt(kv[1]); break;
                     case "o": defaulto = parseInt(kv[1]); break;
                     case "b": defaultb = parseInt(kv[1]); break;

--- a/main.ts
+++ b/main.ts
@@ -28,7 +28,7 @@ namespace music {
 
         const convertNote = (note: string): string => {
             const onote = note.slice(0)
-            // tirm spaces
+            // trim spaces
             let i = 0;
             for(; i < note.length && isSpace(note, i); ++i) {}
             note = note.slice(i)
@@ -36,7 +36,7 @@ namespace music {
             for(i = 0; i < note.length && isDigit(note, i); ++i) {}
             const d = i == 0 ? defaultd : parseInt(note.substr(0, i))
             note = note.slice(i)
-            // note?
+            // note
             const thenote = note.substr(0, 1)
             note = note.slice(1)
             // #?
@@ -47,13 +47,13 @@ namespace music {
             const dot = note.charCodeAt(0) == dotc;
             if (dot)
                 note = note.slice(1);
-            // octave
+            // octave?
             for(i = 0; i < note.length && isDigit(note, i); ++i) {}
             const octave = i == 0 ? defaulto 
                 : parseInt(note.substr(0, i))
             note = note.slice(i)
 
-            let duration = 32 >> d;
+            let duration = Math.floor(32 / d);
             if (dot)
                 duration += duration >> 1;
             // parsed, render to convert
@@ -63,15 +63,34 @@ namespace music {
 
         const parts = notes.split(':')
         const name = parts[0];
+
         parts[1].split(',')
             .map(kvs => kvs.split('='))
             .forEach(kv => {
-                switch(kv[0]) {
+                switch(kv[0]) { // Should be swtich(kv[0].trim())
                     case "d": defaultd = parseInt(kv[1]); break;
                     case "o": defaulto = parseInt(kv[1]); break;
                     case "b": defaultb = parseInt(kv[1]); break;
                 }
             })
+
+        // For some reason, in the code above, I couldn't change
+        //   switch(kv[0])
+        // to
+        //   switch(kv[0].trim())
+        // The compiler kept yelling at me. So, I refactored to this:
+        /*
+        const configs = parts[1].split(',')
+        for (const config of configs) {
+            const kvs = config.split('=')
+            switch (kvs[0].trim()) {
+                case "d": defaultd = parseInt(kvs[1]); break;
+                case "o": defaulto = parseInt(kvs[1]); break;
+                case "b": defaultb = parseInt(kvs[1]); break;
+            }
+        The compiler *still* hates the call to .trim(). No idea why.
+        */
+
         const data = parts[2].split(',')
         // and convert all notes to new format
         const melody = data.map(note => convertNote(note))

--- a/pxt.json
+++ b/pxt.json
@@ -16,7 +16,7 @@
         "device": "*"
     },
     "targetVersions": {
-        "target": "1.2.9",
+        "target": "1.2.10",
         "targetId": "arcade"
     },
     "supportedTargets": [

--- a/test.ts
+++ b/test.ts
@@ -14,7 +14,7 @@ console.log("melody")
 console.log(melody)
 
 control.runInParallel(function() {
-    music.playMelody(melody, 216)    
+    music.playMelody(melody, 216) // Need to play at double-speed
 })
 
 game.splash("play RTTTL tunes", "in your games...")

--- a/test.ts
+++ b/test.ts
@@ -1,4 +1,10 @@
-const demo = `HauntHouse: d=4,o=5,b=108: 2a4, 2e, 2d#, 2b4, 2a4, 2c, 2d, 2a#4, 2e., e, 1f4, 1a4, 1d#, 2e., d, 2c., b4, 1a4, 1p, 2a4, 2e, 2d#, 2b4, 2a4, 2c, 2d, 2a#4, 2e., e, 1f4, 1a4, 1d#, 2e., d, 2c., b4, 1a4`
+// Space before the config section makes parser mad. :-(
+// const demo = `Scale:d=4,o=4,b=120: 1c, 2d., 2e, f., g, 8a, 8a#., 16c5., 16d5, 32e5., 32f5`
+
+const demo = `HauntHouse:d=4,o=5,b=108: 2a4, 2e, 2d#, 2b4, 2a4, 2c, 2d, 2a#4, 2e., e, 1f4, 1a4, 1d#, 2e., d, 2c., b4, 1a4, 1p, 2a4, 2e, 2d#, 2b4, 2a4, 2c, 2d, 2a#4, 2e., e, 1f4, 1a4, 1d#, 2e., d, 2c., b4, 1a4`
+// const demo = `LeisureSuit:d=16,o=6,b=56:f.5,f#.5,g.5,g#5,32a#5,f5,g#.5,a#.5,32f5,g#5,32a#5,g#5,8c#.,a#5,32c#,a5,a#.5,c#.,32a5,a#5,32c#,d#,8e,c#.,f.,f.,f.,f.,f,32e,d#,8d,a#.5,e,32f,e,32f,c#,d#.,c#`
+// const demo = `Scale: d=4,o=4,b=120: 1c, 2d., 2e, f., g, 8a, 8a#., 16c5., 16d5, 32e5., 32f5`
+
 console.log("rttl")
 console.log(demo)
 
@@ -8,7 +14,7 @@ console.log("melody")
 console.log(melody)
 
 control.runInParallel(function() {
-    music.playMelody(melody, 120)    
+    music.playMelody(melody, 216)    
 })
 
 game.splash("play RTTTL tunes", "in your games...")


### PR DESCRIPTION
Switched the calculation from a bit-shift to integer division (i.e. division plus a call to `Math.floor()`). Gives the following translation:

| Note | RTTL Duration | Length (Beats) |
|---|---|---|
| Whole | 1 | 32 |
| Half | 2 | 16 |
| Quarter | 4 | 8 |
| Eighth | 8 | 4 |
| Sixteenth | 16 | 2 |
| 32nd | 32 | 1 |

It makes the notes twice as long as they should be, but it can handle both dotted-sixteenth notes (3 beats) and 32nd notes (1 beat). Easily accommodated by playing the melody at double-speed.

So, at least now, it'll play the theme from *Leisure Suit Larry*. :-D

Also added a note about a semantic error when parsing the configuration section of the RTTL string. If there is a space between the colon after the name and the start of the configuration section, then the first parameter is not parsed (because it is not matched in the `switch` with the added space). A call to `.trim()` throws a compiler error. Even tried refactoring the code; it still complains about the call. I left all of my notes in there.