### PR TITLE
Allow p to indicate a rest per RTTTL spec

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -38,7 +38,7 @@ namespace music {
             const d = i == 0 ? defaultd : parseInt(note.substr(0, i))
             note = note.slice(i)
             // note
-            const thenote = note.substr(0, 1)
+            const thenote = note.substr(0, 1).toUpperCase() == "P" ? "r" : note.substr(0, 1)
             note = note.slice(1)
             // #?
             const hassharp = note.charCodeAt(0) === sharp;

--- a/pxt.json
+++ b/pxt.json
@@ -16,7 +16,7 @@
         "device": "*"
     },
     "targetVersions": {
-        "target": "1.2.9",
+        "target": "1.8.22",
         "targetId": "arcade"
     },
     "supportedTargets": [

--- a/test.ts
+++ b/test.ts
@@ -14,7 +14,7 @@ console.log("melody")
 console.log(melody)
 
 control.runInParallel(function() {
-    music.playMelody(melody, 216) // Need to play at double-speed
+    music.playMelody(melody, 112) // Need to play at double-speed
 })
 
 game.splash("play RTTTL tunes", "in your games...")


### PR DESCRIPTION
Apparently, Nokia used `p` to indicate a rest instead of `r`. I'm altered the note parser to switch a `p` to an `r` to allow for both notations. Refer to https://forum.makecode.com/t/rtttl-tunes-extension/4193/31 for additional information.